### PR TITLE
clean up README.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2016 IdeaSpark Labs.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # Modmerge
-Merge BGEE/BG2EE v2.0 mod zip files back into the main game(making them weidu compatible).
+Merge BGEE/BG2EE v2.0 mod zip files back into the main game(making them weidu
+compatible).
 
-# Downloads/Binaries
-http://github.com/ScottBrooks/modmerge/releases
+# Pre-requisites
 
-# Source build
- - Install golang from http://golang.org
- - go build github.com/ScottBrooks/modmerge/modmerge
+You must have **bought** and **downloaded**:
+
+- Baldur's Gate 1: Enhanced Edition
+- Baldur's Gate 1: Siege of Dragonspear
+- Baldur's Gate 2: Enhanced Edition
+
+# Running
+
+1. Download binary from http://github.com/ScottBrooks/modmerge/releases
+2. Unzip.
+   1. MacOSX only: Rename `/path/to/modmerge-osx` to `/path/to/modmerge`.
+3. Navigate to `/path/to/BG1EE`.
+   - There should be a `chitin.key` file in the directory.
+   - If downloaded with Steam on MacOSX, this should be at `~/Library/Application Support/Steam/steamapps/common/Baldur's Gate Enhanced Edition`.
+   - If downloaded with Steam on Windows, this should be at `C:\Program Files (x86)\Steam\steamapps\common\Baldur's Gate Enhanced Edition`.
+4. Run `/path/to/modmerge`. If you see `Conversion complete.`, it worked!
 
 # Details
 
@@ -21,19 +34,13 @@ modmerge does the following
  
 The end result, assuming everything is successful, is you will have an updated chitin.key that points to the resources from the base game, and the resources from the mod, that weidu, near infinity, DLTCEP, etc will all be able to load.
 
+# Building from source
+
+```
+cd /path/to/modmerge
+go build github.com/scottbrooks/modmerge/modmerge
+```
+
 # Redistribution
 
 You are free to package or redistribute modmerge.
-
-# License
-
-Copyright (c) 2016 IdeaSpark Labs.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-


### PR DESCRIPTION
- Remove build instructions (self explanatory).
- Add explicit running instructions (missing, and was hard for me to figure
  out - esp where chitin.key lives).
- Move license to LICENSE, per github/oss standard.